### PR TITLE
Rename tasks variable

### DIFF
--- a/src/Controllers/MechanicController.php
+++ b/src/Controllers/MechanicController.php
@@ -29,7 +29,7 @@ class MechanicController {
         $appts = $this->apptM->getForMechanic($mechanicId, $today);
 
         // Φέρνουμε όσες εργασίες έχουν completion_time την ίδια μέρα
-        $tasks = $this->taskM->getByMechanic($mechanicId, $today);
+        $tasksToday = $this->taskM->getByMechanic($mechanicId, $today);
 
         $token = generateCsrfToken();
         include __DIR__ . '/../../views/mechanic_dashboard.php';


### PR DESCRIPTION
## Summary
- rename `$tasks` to `$tasksToday` in MechanicController

## Testing
- `php Tests/test_task.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a8d601b4833384d6837983eb0e45