### PR TITLE
Hide auth links when logged in

### DIFF
--- a/Views/appointment_form.php
+++ b/Views/appointment_form.php
@@ -6,6 +6,9 @@
   <title><?= isset($appt) ? 'Edit Appointment' : 'New Appointment' ?></title>
 </head>
 <body>
+<?php include __DIR__ . '/../public/inc/header.php'; ?>
+<section class="hero-background">
+  <div class="container" style="background-color: rgba(0, 0, 0, 0.8); padding: 20px; border-radius: 10px; box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);">
   <p>
     <a href="appointments.php">← Επιστροφή στα Ραντεβού</a>
   </p>
@@ -202,5 +205,8 @@
     // Καθαρίζουμε το old_appt data
     unset($_SESSION['old_appt']);
   ?>
+</div>
+</section>
+<?php include __DIR__ . '/../public/inc/footer.php'; ?>
 </body>
 </html>

--- a/Views/appointments.php
+++ b/Views/appointments.php
@@ -6,6 +6,9 @@
   <title>Appointments</title>
 </head>
 <body>
+<?php include __DIR__ . '/../public/inc/header.php'; ?>
+<section class="hero-background">
+  <div class="container" style="background-color: rgba(0, 0, 0, 0.8); padding: 20px; border-radius: 10px; box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);">
   <h1>Appointments</h1>
 
   <?php if (!empty($_SESSION['success'])): ?>
@@ -153,5 +156,8 @@
       <?php endfor; ?>
     </p>
   <?php endif; ?>
+</div>
+</section>
+<?php include __DIR__ . '/../public/inc/footer.php'; ?>
 </body>
 </html>

--- a/Views/appointments_mechanic.php
+++ b/Views/appointments_mechanic.php
@@ -4,6 +4,9 @@
   <link rel="stylesheet" href="css/style.css">
   <meta charset="UTF-8"><title>Τα Ραντεβού μου</title></head>
 <body>
+<?php include __DIR__ . '/../public/inc/header.php'; ?>
+<section class="hero-background">
+  <div class="container" style="background-color: rgba(0, 0, 0, 0.8); padding: 20px; border-radius: 10px; box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);">
   <h1>Ραντεβού Μηχανικού</h1>
 
   <?php if(!empty($_SESSION['success'])): ?>
@@ -52,5 +55,8 @@
   </table>
 
   <p><a href="dashboard.php">Επιστροφή</a></p>
+</div>
+</section>
+<?php include __DIR__ . '/../public/inc/footer.php'; ?>
 </body>
 </html>

--- a/Views/car_form.php
+++ b/Views/car_form.php
@@ -6,6 +6,9 @@
   <title><?= isset($car) ? 'Edit Car' : 'New Car' ?></title>
 </head>
 <body>
+<?php include __DIR__ . '/../public/inc/header.php'; ?>
+<section class="hero-background">
+  <div class="container" style="background-color: rgba(0, 0, 0, 0.8); padding: 20px; border-radius: 10px; box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);">
   <p>
     <a href="cars.php">← Επιστροφή στη Λίστα Αυτοκινήτων</a>
   </p>
@@ -218,5 +221,8 @@
     // Καθαρίζουμε το old_car data
     unset($_SESSION['old_car']);
   ?>
+</div>
+</section>
+<?php include __DIR__ . '/../public/inc/footer.php'; ?>
 </body>
 </html>

--- a/Views/cars.php
+++ b/Views/cars.php
@@ -6,6 +6,9 @@
   <title>Cars (Page <?= htmlspecialchars($page) ?> of <?= htmlspecialchars($totalPages) ?>)</title>
 </head>
 <body>
+<?php include __DIR__ . '/../public/inc/header.php'; ?>
+<section class="hero-background">
+  <div class="container" style="background-color: rgba(0, 0, 0, 0.8); padding: 20px; border-radius: 10px; box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);">
   <h1>Cars</h1>
 
   <!-- Εμφάνιση μηνυμάτων επιτυχίας/σφάλματος -->
@@ -126,5 +129,8 @@
     </div>
   <?php endif; ?>
 
+</div>
+</section>
+<?php include __DIR__ . '/../public/inc/footer.php'; ?>
 </body>
 </html>

--- a/Views/customer_dashboard.php
+++ b/Views/customer_dashboard.php
@@ -14,6 +14,9 @@
   </style>
 </head>
 <body>
+<?php include __DIR__ . '/../public/inc/header.php'; ?>
+<section class="hero-background">
+  <div class="container" style="background-color: rgba(0, 0, 0, 0.8); padding: 20px; border-radius: 10px; box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);">
   <?php
   require_once __DIR__ . '/../src/Models/User.php';
   use Models\User;
@@ -111,5 +114,8 @@
     <a href="dashboard.php">Γενικός Πίνακας Ελέγχου</a> |
     <a href="logout.php">Αποσύνδεση</a>
   </p>
+</div>
+</section>
+<?php include __DIR__ . '/../public/inc/footer.php'; ?>
 </body>
 </html>

--- a/Views/dashboard.php
+++ b/Views/dashboard.php
@@ -6,6 +6,9 @@
   <title>Dashboard</title>
 </head>
 <body>
+<?php include __DIR__ . '/../public/inc/header.php'; ?>
+<section class="hero-background">
+  <div class="container" style="background-color: rgba(0, 0, 0, 0.8); padding: 20px; border-radius: 10px; box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);">
   <header style="text-align: center; margin: 0; font-size: 1.5rem; color: #333; position: relative;">
     <h1>Πίνακας ελέγχου του χρήστη <?php echo htmlspecialchars($username); ?></h1>
     <button class="btn btn-danger" style="position: absolute; top: 10px; right: 10px; font-size: 0.9rem; padding: 5px 10px;">
@@ -33,5 +36,8 @@
       <p>Καλωσήρθες, <?= htmlspecialchars($username) ?> (<?= htmlspecialchars($role) ?>)!</p>
     </main>
   </div>
+</div>
+</section>
+<?php include __DIR__ . '/../public/inc/footer.php'; ?>
 </body>
 </html>

--- a/Views/mechanic_dashboard.php
+++ b/Views/mechanic_dashboard.php
@@ -6,6 +6,9 @@
   <title>Mechanic Dashboard</title>
 </head>
 <body>
+<?php include __DIR__ . '/../public/inc/header.php'; ?>
+<section class="hero-background">
+  <div class="container" style="background-color: rgba(0, 0, 0, 0.8); padding: 20px; border-radius: 10px; box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);">
   <?php
     // Υποθέτουμε ότι ο controller έχει περάσει:
     //   $today      → string, π.χ. '2025-06-02'
@@ -72,5 +75,8 @@
     <p><em>Δεν υπάρχουν εργασίες για σήμερα.</em></p>
   <?php endif; ?>
 
+</div>
+</section>
+<?php include __DIR__ . '/../public/inc/footer.php'; ?>
 </body>
 </html>

--- a/Views/task_form.php
+++ b/Views/task_form.php
@@ -13,6 +13,9 @@
   </style>
 </head>
 <body>
+<?php include __DIR__ . '/../public/inc/header.php'; ?>
+<section class="hero-background">
+  <div class="container" style="background-color: rgba(0, 0, 0, 0.8); padding: 20px; border-radius: 10px; box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);">
   <h1><?= isset($task) ? 'Επεξεργασία Εργασίας #' . htmlspecialchars($task['id']) : 'Προσθήκη Νέας Εργασίας' ?></h1>
 
   <?php if (!empty($_SESSION['error'])): ?>
@@ -95,5 +98,8 @@
     &nbsp;
     <a href="tasks.php">Ακύρωση</a>
   </form>
+</div>
+</section>
+<?php include __DIR__ . '/../public/inc/footer.php'; ?>
 </body>
 </html>

--- a/Views/tasks_mechanic.php
+++ b/Views/tasks_mechanic.php
@@ -6,6 +6,9 @@
   <title>Οι Εργασίες Μου</title>
 </head>
 <body>
+<?php include __DIR__ . '/../public/inc/header.php'; ?>
+<section class="hero-background">
+  <div class="container" style="background-color: rgba(0, 0, 0, 0.8); padding: 20px; border-radius: 10px; box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);">
   <h1>Οι Εργασίες Μου</h1>
 
   <?php if (!empty($_SESSION['success'])): ?>
@@ -119,5 +122,8 @@
   <p class="back-link">
     <a href="dashboard.php">&larr; Επιστροφή στο Dashboard</a>
   </p>
+</div>
+</section>
+<?php include __DIR__ . '/../public/inc/footer.php'; ?>
 </body>
 </html>

--- a/Views/user_form.php
+++ b/Views/user_form.php
@@ -6,6 +6,9 @@
   <title>Edit User</title>
 </head>
 <body>
+<?php include __DIR__ . '/../public/inc/header.php'; ?>
+<section class="hero-background">
+  <div class="container" style="background-color: rgba(0, 0, 0, 0.8); padding: 20px; border-radius: 10px; box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);">
   <h1>Edit User #<?= htmlspecialchars($user['id']) ?></h1>
 
   <?php if (!empty($_SESSION['error'])): ?>
@@ -48,5 +51,8 @@
     <button type="submit">Save</button>
     <a href="users.php">Cancel</a>
   </form>
+</div>
+</section>
+<?php include __DIR__ . '/../public/inc/footer.php'; ?>
 </body>
 </html>

--- a/Views/users.php
+++ b/Views/users.php
@@ -7,6 +7,9 @@
   <style> form.inline{display:inline;} </style>
 </head>
 <body>
+<?php include __DIR__ . '/../public/inc/header.php'; ?>
+<section class="hero-background">
+  <div class="container" style="background-color: rgba(0, 0, 0, 0.8); padding: 20px; border-radius: 10px; box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);">
   <h1>Users (<?= htmlspecialchars($mode) ?>)</h1>
   <p>
     <a href="users.php?mode=all">All</a> |
@@ -81,5 +84,8 @@
       </tr>
     <?php endforeach; ?>
   </table>
+</div>
+</section>
+<?php include __DIR__ . '/../public/inc/footer.php'; ?>
 </body>
 </html>

--- a/public/inc/header.php
+++ b/public/inc/header.php
@@ -1,5 +1,8 @@
 <?php
-// public/inc/header.php 
+// public/inc/header.php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
 ?>
 <!-- Reusable Header -->
 <header class="site-header">
@@ -12,11 +15,16 @@
       <a href="about.php">Σχετικά</a>
       <a href="services.php">Υπηρεσίες</a>
       <a href="contact.php">Επικοινωνία</a>
+      <?php if (empty($_SESSION['user_id'])): ?>
       <a href="register.php" class="btn-register" style="font-size: 0.7rem; padding: 4px 8px; margin-left: 100px; border-radius: 6px;">Εγγραφή</a>
       <a href="login.php" class="btn-login" style="font-size: 0.7rem; padding: 4px 8px; margin-left: 10px; border-radius: 6px;">Login</a>
+      <?php endif; ?>
     </nav>
     <div class="workshop-title" style="position: absolute; right: 20px; top: 15px;">
-      <h1 style="font-size: 1.5rem; color: #f1c40f;">Car Workshop</h1>
+      <?php if (!empty($_SESSION['user_id'])): ?>
+      <a href="logout.php" class="btn-login" style="font-size: 0.7rem; padding: 4px 8px; margin-right: 10px; border-radius: 6px;">Αποσύνδεση</a>
+      <?php endif; ?>
+      <h1 style="font-size: 1.5rem; color: #f1c40f; display: inline-block;">Car Workshop</h1>
     </div>
   </div>
 </header>


### PR DESCRIPTION
## Summary
- update shared header to start a session when needed
- hide Register/Login links if the user is already logged in
- show Logout link next to the Car Workshop title

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845af0009888333b490327154e0c58a